### PR TITLE
Small typo on main_concepts.md

### DIFF
--- a/docs/main_concepts.md
+++ b/docs/main_concepts.md
@@ -134,7 +134,7 @@ users to focus on the content in your app while still having access to UI
 controls.
 
 For example, if you want to add a selectbox and a slider to a sidebar, just
-use `st.sidebar.slider` and `st.siderbar.selectbox` instead of `st.slider` and
+use `st.sidebar.slider` and `st.sidebar.selectbox` instead of `st.slider` and
 `st.selectbox`:
 
 ```python


### PR DESCRIPTION
fixed typo: `st.siderbar.selectbox` to `st.sidebar.selectbox`

**Issue:** No issue created; very small typo

**Description:** 
- changed `st.siderbar.selectbox` to `st.sidebar.selectbox` within `main_concepts.md`. 
